### PR TITLE
fix: add meta tags and lang to index and sales pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # cookie-stand
 Salmon Cookies Project
+
+---
+
+## Revamp Tracking (2026-05-17)
+
+### Quick Wins
+- ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/style.css">
     <title>Simpliciano Salmon Cookies</title>

--- a/sales.html
+++ b/sales.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/style.css">
     <title>Cookie Sales</title>


### PR DESCRIPTION
## Summary
- Added `lang="en"`, `charset="UTF-8"`, and `viewport` meta tags to `index.html` and `sales.html`
- `about-pat.html` and `merch.html` already had these; now all pages are consistent

## Test plan
- [ ] Open each page — no encoding issues, mobile scaling works