### PR TITLE
fix: replace duplicate id="foot-p" with class

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Salmon Cookies Project
 
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages
+- ✅ QW-2: Fix duplicate id="foot-p" → class (`revamp/qw-2-fix-duplicate-ids`) — replaced 5 duplicate IDs with class="foot-p", updated CSS selector

--- a/css/style.css
+++ b/css/style.css
@@ -117,7 +117,7 @@ h2 {
   width: 100%;
 }
 
-#foot-p {
+.foot-p {
   height: 10px;
   font-size: 10px;
 }

--- a/index.html
+++ b/index.html
@@ -48,19 +48,19 @@
     <footer>
       <ul>
         <li>
-          <p id="foot-p">Seattle</p>
+          <p class="foot-p">Seattle</p>
         </li>
         <li>
-          <p id="foot-p">Tokyo</p>
+          <p class="foot-p">Tokyo</p>
         </li>
         <li>
-          <p id="foot-p">Dubai</p>
+          <p class="foot-p">Dubai</p>
         </li>
         <li>
-          <p id="foot-p">Paris</p>
+          <p class="foot-p">Paris</p>
         </li>
         <li>
-          <p id="foot-p">Lima</p>
+          <p class="foot-p">Lima</p>
         </li>
       </ul>
       <p>&copy; Simpliciano</p>


### PR DESCRIPTION
## Summary
- Five footer `<p>` elements shared `id="foot-p"` — IDs must be unique per page
- Changed all to `class="foot-p"` and updated the CSS selector accordingly

## Test plan
- [ ] Footer location labels still display correctly on index.html