### PR TITLE
fix: correct City label for attribute in sales form

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Salmon Cookies Project
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages
 - ✅ QW-2: Fix duplicate id="foot-p" → class (`revamp/qw-2-fix-duplicate-ids`) — replaced 5 duplicate IDs with class="foot-p", updated CSS selector
+- ✅ QW-3: Fix form label mismatch in sales.html (`revamp/qw-3-fix-form-label`) — corrected label for="city" → for="location" to match input id

--- a/sales.html
+++ b/sales.html
@@ -35,7 +35,7 @@
     </section>
     <h3>New Sales Data</h3>
     <form id="my-Form">
-      <label for="city">City</label>
+      <label for="location">City</label>
       <input type="text" id="location" name="location"> <hr>
       <label for="minCust">Min Cust</label>
       <input type="text" id="minCust" name="minCust"><hr>


### PR DESCRIPTION
## Summary
- `<label for="city">` targeted a non-existent element; the input's actual id is `"location"`
- Fixed to `<label for="location">` so clicking the label focuses the input

## Test plan
- [ ] Clicking "City" label in the sales form focuses the city text input