### PR TITLE
fix: remove stray console.log from app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Salmon Cookies Project
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages
 - ✅ QW-2: Fix duplicate id="foot-p" → class (`revamp/qw-2-fix-duplicate-ids`) — replaced 5 duplicate IDs with class="foot-p", updated CSS selector
 - ✅ QW-3: Fix form label mismatch in sales.html (`revamp/qw-3-fix-form-label`) — corrected label for="city" → for="location" to match input id
+- ✅ QW-4: Remove console.log from app.js (`revamp/qw-4-remove-consolelog`) — removed stray console.log(grandTotal) left from development

--- a/js/app.js
+++ b/js/app.js
@@ -116,7 +116,6 @@ getHourlyTotals();
 // console.log(totalArray);
 
 // RENDER TABLE FOOTER
-console.log(grandTotal);
 let renderTableFooter = function () {
   // row
   let newRowElem = document.createElement('tr');


### PR DESCRIPTION
## Summary
- Removed `console.log(grandTotal)` that was left in from debugging

## Test plan
- [ ] Open browser devtools on sales.html — no console output on page load