### PR TITLE
perf: add loading=lazy to all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Salmon Cookies Project
 - ✅ QW-3: Fix form label mismatch in sales.html (`revamp/qw-3-fix-form-label`) — corrected label for="city" → for="location" to match input id
 - ✅ QW-4: Remove console.log from app.js (`revamp/qw-4-remove-consolelog`) — removed stray console.log(grandTotal) left from development
 - ✅ QW-5: Delete scratch files (`revamp/qw-5-remove-scratch-files`) — removed whiteboard.html and whiteboard.js from project root
+- ✅ QW-6: Add loading="lazy" to all images (`revamp/qw-6-lazy-loading`) — defers off-screen image loading across all pages

--- a/about-pat.html
+++ b/about-pat.html
@@ -22,7 +22,7 @@
   </header>
   <main>
     <p>Meet our GM, Pat!</p>
-    <img id="family" src="img/family.jpg" alt="family">
+    <img id="family" src="img/family.jpg" alt="family" loading="lazy">
   </main>
   <footer>
     hey

--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
       </nav>
     </header>
     <ul>
-      <li><img id="chinook" src="img/chinook.jpg" alt="chinook"></li>
-      <li><img id="cutter" src="img/cutter.jpeg" alt="cutter"></li>
-      <li><img id="fish" src="img/fish.jpg" alt="fish"></li>
-      <img id="frosted-cookie" src="img/frosted-cookie.jpg" alt="placeholder">
+      <li><img id="chinook" src="img/chinook.jpg" alt="chinook" loading="lazy"></li>
+      <li><img id="cutter" src="img/cutter.jpeg" alt="cutter" loading="lazy"></li>
+      <li><img id="fish" src="img/fish.jpg" alt="fish" loading="lazy"></li>
+      <img id="frosted-cookie" src="img/frosted-cookie.jpg" alt="placeholder" loading="lazy">
     </ul>
     <section>
         <article>

--- a/merch.html
+++ b/merch.html
@@ -22,7 +22,7 @@
   </header>
   <main>
     <p>Check out our sweet Salmon Cookie Shirts!</p>
-    <img id="shirt" src="img/shirt.jpg" alt="shirt">
+    <img id="shirt" src="img/shirt.jpg" alt="shirt" loading="lazy">
   </main>
   <footer>
     hey


### PR DESCRIPTION
## Summary
- Added `loading="lazy"` to all `<img>` tags across index, about-pat, and merch pages
- Defers loading of off-screen images until the user scrolls near them

## Test plan
- [ ] Images still display correctly on all pages
- [ ] DevTools Network tab shows images loading on demand when scrolling