### PR TITLE
fix: fix broken HTML structure in index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Salmon Cookies Project
 
 ## Revamp Tracking (2026-05-17)
 
+### Moderate
+- ✅ MOD-7: Fix broken HTML structure in index.html (`revamp/mod-7-fix-html-structure`) — added missing &lt;main&gt; tag, wrapped bare &lt;img&gt; in &lt;li&gt;
+
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages
 - ✅ QW-2: Fix duplicate id="foot-p" → class (`revamp/qw-2-fix-duplicate-ids`) — replaced 5 duplicate IDs with class="foot-p", updated CSS selector

--- a/index.html
+++ b/index.html
@@ -19,26 +19,27 @@
         </ul>
       </nav>
     </header>
+    <main>
     <ul>
       <li><img id="chinook" src="img/chinook.jpg" alt="chinook" loading="lazy"></li>
       <li><img id="cutter" src="img/cutter.jpeg" alt="cutter" loading="lazy"></li>
       <li><img id="fish" src="img/fish.jpg" alt="fish" loading="lazy"></li>
-      <img id="frosted-cookie" src="img/frosted-cookie.jpg" alt="placeholder" loading="lazy">
+      <li><img id="frosted-cookie" src="img/frosted-cookie.jpg" alt="placeholder" loading="lazy"></li>
     </ul>
     <section>
         <article>
           <h2>Store Info</h2>
           <p>
             Store Info: <hr>
-            Seattle: 6am-8pm 
+            Seattle: 6am-8pm
             <br>12 Cookie St, Seattle, Wa, 98101 <hr>
-            Tokyo: 6am-8pm 
+            Tokyo: 6am-8pm
             <br>12 Cookie St、シアトル、ワシントン州、 <hr>
-            Dubai: 6am-8pm 
+            Dubai: 6am-8pm
             <br>12 شارع كوكي ، سياتل ، وا 98101 <hr>
-            Paris: 6am-8pm 
+            Paris: 6am-8pm
             <br>12 Rue Biscuit, Paris, France<hr>
-            Lima: 6am-8pm 
+            Lima: 6am-8pm
             <br>12 Calle Galleta, Lima, Peru <hr>
         </p>
         <button>Something Cool</button>


### PR DESCRIPTION
## Summary
- Added missing opening `<main>` tag — the page had `</main>` with no opening tag, causing browsers to silently discard it
- Wrapped the bare `<img id="frosted-cookie">` in an `<li>` — an `<img>` directly inside `<ul>` is invalid HTML

## Test plan
- [ ] W3C validator reports no structural errors on index.html
- [ ] All images in the gallery row still display correctly