### PR TITLE
refactor: replace float layout with Flexbox in nav and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Salmon Cookies Project
 ### Moderate
 - ✅ MOD-7: Fix broken HTML structure in index.html (`revamp/mod-7-fix-html-structure`) — added missing &lt;main&gt; tag, wrapped bare &lt;img&gt; in &lt;li&gt;
 - ✅ MOD-8: Extract color palette to CSS custom properties (`revamp/mod-8-css-variables`) — 5 brand colors in :root, all hex values replaced with var()
+- ✅ MOD-9: Replace float layout with Flexbox in nav and footer (`revamp/mod-9-flexbox-nav-footer`) — nav icon + links aligned with flex; footer locations evenly spaced with flex
 
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages

--- a/css/style.css
+++ b/css/style.css
@@ -62,27 +62,25 @@ header {
 } 
 
 nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   width: 100%;
-  margin: auto;
-  justify-content: space-between;
   font-family: 'Montserrat', sans-serif;
-  color:var(--color-coral);
+  color: var(--color-coral);
 }
 
 nav img {
-  float: left;
-  margin-top: 15px;
-  margin-right: 10px;
   height: 20px;
 }
 
 nav ul {
   display: flex;
+  gap: 20px;
 }
 
 nav ul li {
-  margin-top: 10px;
-  margin-right: 20px;
+  margin-top: 0;
 }
 
 a {
@@ -148,13 +146,15 @@ footer {
 }
 
 footer ul {
+  display: flex;
   justify-content: space-evenly;
+  align-items: center;
+  padding: 8px 0;
 }
 
 footer ul li {
-  float: left;
-  height: 5px;
   width: 50px;
+  text-align: center;
 }
 
 /* footer p {


### PR DESCRIPTION
## Summary
- Nav: replaced `float: left` on icon with `display: flex; align-items: center; gap` on the nav — icon and links align cleanly
- Footer: added `display: flex; justify-content: space-evenly` to `footer ul` (was missing, so the existing `justify-content` had no effect); removed `float: left` from `li`

## Test plan
- [ ] Nav icon and links sit on the same baseline on all pages
- [ ] Footer city names are evenly spaced horizontally