### PR TITLE
fix: update footer totals when new store added via form

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Salmon Cookies Project
 - ✅ MOD-7: Fix broken HTML structure in index.html (`revamp/mod-7-fix-html-structure`) — added missing &lt;main&gt; tag, wrapped bare &lt;img&gt; in &lt;li&gt;
 - ✅ MOD-8: Extract color palette to CSS custom properties (`revamp/mod-8-css-variables`) — 5 brand colors in :root, all hex values replaced with var()
 - ✅ MOD-9: Replace float layout with Flexbox in nav and footer (`revamp/mod-9-flexbox-nav-footer`) — nav icon + links aligned with flex; footer locations evenly spaced with flex
+- ✅ MOD-10: Fix table footer not updating after form submission (`revamp/mod-10-fix-table-footer-update`) — recompute totals and re-render footer row on each new store addition
 
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages

--- a/js/app.js
+++ b/js/app.js
@@ -102,21 +102,23 @@ cookieStore.prototype.render = function () {
 let totalArray = []
 let grandTotal = 0
 let getHourlyTotals = function () {
+  totalArray = [];
+  grandTotal = 0;
   for (let i = 0; i < businessHours.length; i++) {
-  let hourlyTotal = 0;
+    let hourlyTotal = 0;
     for (let j = 0; j < internationalStores.length; j++) {
-    hourlyTotal += internationalStores[j].salesArr[i];
+      hourlyTotal += internationalStores[j].salesArr[i];
+    }
+    totalArray.push(hourlyTotal);
+    grandTotal = sum(grandTotal, hourlyTotal);
   }
-  totalArray.push(hourlyTotal);
-  grandTotal = sum(grandTotal, hourlyTotal)
-  // console.log(hourlyTotal);
-}
 }
 getHourlyTotals();
 // console.log(totalArray);
 
 // RENDER TABLE FOOTER
 let renderTableFooter = function () {
+  tableFoot.innerHTML = '';
   // row
   let newRowElem = document.createElement('tr');
   tableFoot.appendChild(newRowElem);
@@ -148,7 +150,8 @@ function handleSubmit(event) {
   let AvgCookiesPerSale = +event.target.AvgCookiesPerSale.value;
 
   new cookieStore(location, minCust, maxCust, AvgCookiesPerSale);
-
+  getHourlyTotals();
+  renderTableFooter();
 }
 
 // ****************************************


### PR DESCRIPTION
## Summary
- `getHourlyTotals` now resets `totalArray` and `grandTotal` before recomputing, so it can be called multiple times correctly
- `renderTableFooter` clears the existing footer row (`tableFoot.innerHTML = ''`) before appending a new one
- `handleSubmit` calls both after creating the new store, so the grand total row reflects all stores including the newly added one

## Test plan
- [ ] Add a new store via the form — grand total row updates to include the new store's sales
- [ ] Submit the form multiple times — totals accumulate correctly each time