### PR TITLE
fix: use type=number with validation on sales form inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Salmon Cookies Project
 - ✅ MOD-8: Extract color palette to CSS custom properties (`revamp/mod-8-css-variables`) — 5 brand colors in :root, all hex values replaced with var()
 - ✅ MOD-9: Replace float layout with Flexbox in nav and footer (`revamp/mod-9-flexbox-nav-footer`) — nav icon + links aligned with flex; footer locations evenly spaced with flex
 - ✅ MOD-10: Fix table footer not updating after form submission (`revamp/mod-10-fix-table-footer-update`) — recompute totals and re-render footer row on each new store addition
+- ✅ MOD-11: Change numeric form inputs to type="number" (`revamp/mod-11-number-inputs`) — minCust, maxCust, AvgCookiesPerSale now use number inputs with min=0 and required
 
 ### Quick Wins
 - ✅ QW-1: Add meta tags and lang to index.html and sales.html (`revamp/qw-1-meta-tags`) — added charset, viewport, lang="en" to both pages

--- a/sales.html
+++ b/sales.html
@@ -36,13 +36,13 @@
     <h3>New Sales Data</h3>
     <form id="my-Form">
       <label for="location">City</label>
-      <input type="text" id="location" name="location"> <hr>
-      <label for="minCust">Min Cust</label>
-      <input type="text" id="minCust" name="minCust"><hr>
-      <label for="maxCust">Max Cust</label>
-      <input type="text" id="maxCust" name="maxCust"><hr>
-      <label for="AvgCookiesPerSale">Average Sale</label>
-      <input type="text" id="AvgCookiesPerSale" name="AvgCookiesPerSale">
+      <input type="text" id="location" name="location" required> <hr>
+      <label for="minCust">Min Customers</label>
+      <input type="number" id="minCust" name="minCust" min="0" required><hr>
+      <label for="maxCust">Max Customers</label>
+      <input type="number" id="maxCust" name="maxCust" min="0" required><hr>
+      <label for="AvgCookiesPerSale">Avg Cookies Per Sale</label>
+      <input type="number" id="AvgCookiesPerSale" name="AvgCookiesPerSale" min="0" step="0.1" required>
       <input type="submit">
     </form>
   </main>


### PR DESCRIPTION
## Summary
- Changed `minCust`, `maxCust`, and `AvgCookiesPerSale` inputs from `type="text"` to `type="number"`
- Added `min="0"` to prevent negative values; added `step="0.1"` on avg cookies to allow decimals
- Added `required` to all fields so the form won't submit with empty inputs
- Improved label text for clarity ("Min Customers", "Avg Cookies Per Sale")

## Test plan
- [ ] Non-numeric input is rejected by the browser before form submission
- [ ] Submitting with empty fields shows browser validation errors
- [ ] Decimal values (e.g. 6.3) are accepted in the avg field