### PR TITLE
refactor: extract store config data to js/data.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Salmon Cookies Project
 
 ### Deep Refactors
 - ✅ DEEP-12: Convert cookieStore to ES6 class (`revamp/deep-12-es6-class`) — rewritten as class CookieStore with constructor and methods; consistent camelCase naming
+- ✅ DEEP-13: Extract store config data to data.js (`revamp/deep-13-store-data`) — store locations/ranges in js/data.js storeData array; app.js loops over it
 
 ### Moderate
 - ✅ MOD-7: Fix broken HTML structure in index.html (`revamp/mod-7-fix-html-structure`) — added missing &lt;main&gt; tag, wrapped bare &lt;img&gt; in &lt;li&gt;

--- a/js/app.js
+++ b/js/app.js
@@ -63,12 +63,10 @@ class CookieStore {
   }
 }
 
-// INSTANTIATE INTERNATIONAL STORES
-new CookieStore('Seattle', 23, 65, 6.3);
-new CookieStore('Tokyo', 3, 24, 1.2);
-new CookieStore('Dubai', 11, 38, 3.7);
-new CookieStore('Paris', 20, 38, 2.3);
-new CookieStore('Lima', 2, 16, 4.6);
+// INSTANTIATE INTERNATIONAL STORES from data.js
+for (let store of storeData) {
+  new CookieStore(store.location, store.minCust, store.maxCust, store.avgCookiesPerSale);
+}
 
 // *** RENDER TABLE HEADER ***
 let renderTableHeader = function () {

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const storeData = [
+  { location: 'Seattle', minCust: 23, maxCust: 65, avgCookiesPerSale: 6.3 },
+  { location: 'Tokyo',   minCust: 3,  maxCust: 24, avgCookiesPerSale: 1.2 },
+  { location: 'Dubai',   minCust: 11, maxCust: 38, avgCookiesPerSale: 3.7 },
+  { location: 'Paris',   minCust: 20, maxCust: 38, avgCookiesPerSale: 2.3 },
+  { location: 'Lima',    minCust: 2,  maxCust: 16, avgCookiesPerSale: 4.6 },
+];

--- a/sales.html
+++ b/sales.html
@@ -46,6 +46,7 @@
       <input type="submit">
     </form>
   </main>
+    <script src="js/data.js"></script>
     <script src="js/app.js"></script>
     <footer>Simpliciano</footer>
   </body>


### PR DESCRIPTION
## Summary
- Created `js/data.js` with a `storeData` array containing location name, min/max customers, and avg cookies per sale for each store
- `app.js` now loops over `storeData` to instantiate stores instead of five separate hardcoded `new CookieStore(...)` calls
- Adding or removing a store is now a one-line change in `data.js`
- `data.js` loaded before `app.js` in `sales.html`

## Test plan
- [ ] Sales table renders all 5 stores correctly on page load
- [ ] Adding a store via the form still works and updates totals